### PR TITLE
chore(go): add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/Netcracker/qubership-tcp-duplicator
 
 go 1.26.1
+toolchain go1.26.4


### PR DESCRIPTION
Add `toolchain go1.26.4` directive to `go.mod` to pin the Go toolchain version.